### PR TITLE
support for idle_timeout

### DIFF
--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -20,7 +20,7 @@ module "alb" {
   ]
 
   idle_timeout = 120
-  type = "application"
+  type         = "application"
 
   tags {
     environment = "prod"

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -19,6 +19,7 @@ module "alb" {
     "${data.aws_subnet_ids.main.ids}",
   ]
 
+  idle_timeout = 120
   type = "application"
 
   tags {

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_lb" "main" {
   internal           = "${var.internal}"
   subnets            = ["${var.subnet_ids}"]
   security_groups    = ["${aws_security_group.main.*.id}"]
+  idle_timeout       = "${var.idle_timeout}"
 
   tags = "${merge(var.tags, map("Name", "${local.name_prefix}"))}"
 }

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_lb" "main_with_access_logs" {
   internal           = "${var.internal}"
   subnets            = ["${var.subnet_ids}"]
   security_groups    = ["${aws_security_group.main.*.id}"]
+  idle_timeout       = "${var.idle_timeout}"
 
   access_logs = {
     prefix  = "${var.access_logs_prefix}"

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "access_logs_bucket" {
   default     = ""
 }
 
+variable "idle_timeout" {
+  description = "(Optional) The time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type application. Default: 60."
+  default     = 60
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = "map"


### PR DESCRIPTION
The governance portal team needs to set the property idle_timeout to keep the connection up longer than 60 seconds to the client.