### PR TITLE
Optional Cloudwatch Dashboard with metrics for the load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,7 @@
 [![Build Status](https://travis-ci.com/telia-oss/terraform-aws-loadbalancer.svg?branch=master)](https://travis-ci.com/telia-oss/terraform-aws-loadbalancer)
 
 Module for creating an ALB or NLB. In the case of an ALB it also takes care of setting up
-a security group with all egress.
+a security group with all egress. The module however, does not create ingress security group rules. See the default example on how to do that.
+
+The module can also create a Cloud Watch Dashboard that will display target response times,
+active connections and request count.

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -15,6 +15,8 @@ module "alb" {
   name_prefix = "example"
   vpc_id      = "${data.aws_vpc.main.id}"
 
+  add_cloudwatch_dashboard = "true"
+
   subnet_ids = [
     "${data.aws_subnet_ids.main.ids}",
   ]

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -12,7 +12,7 @@ data "aws_subnet_ids" "main" {
 
 module "alb" {
   source      = "../../"
-  name_prefix = "example"
+  name_prefix = "example-bech-34"
   vpc_id      = "${data.aws_vpc.main.id}"
 
   subnet_ids = [
@@ -34,6 +34,8 @@ module "alb_nobucket" {
   source      = "../../"
   name_prefix = "example-2"
   vpc_id      = "${data.aws_vpc.main.id}"
+
+  add_cloudwatch_dashboard = "true"
 
   subnet_ids = [
     "${data.aws_subnet_ids.main.ids}",
@@ -63,7 +65,7 @@ resource "aws_security_group_rule" "ingress_80" {
 // see https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
 
 resource "aws_s3_bucket" "elb" {
-  bucket = "terraform-aws-loadbalancer-changeme"
+  bucket = "terraform-aws-loadbalancer-c12313"
 
   policy = <<EOF
 {
@@ -75,7 +77,7 @@ resource "aws_s3_bucket" "elb" {
       "AWS": "arn:aws:iam::156460612806:root"
     },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::terraform-aws-loadbalancer-changeme/*"
+      "Resource": "arn:aws:s3:::terraform-aws-loadbalancer-c12313/*"
     }
   ]
   }

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -12,7 +12,7 @@ data "aws_subnet_ids" "main" {
 
 module "alb" {
   source      = "../../"
-  name_prefix = "example-bech-34"
+  name_prefix = "example"
   vpc_id      = "${data.aws_vpc.main.id}"
 
   subnet_ids = [
@@ -34,8 +34,6 @@ module "alb_nobucket" {
   source      = "../../"
   name_prefix = "example-2"
   vpc_id      = "${data.aws_vpc.main.id}"
-
-  add_cloudwatch_dashboard = "true"
 
   subnet_ids = [
     "${data.aws_subnet_ids.main.ids}",
@@ -65,7 +63,7 @@ resource "aws_security_group_rule" "ingress_80" {
 // see https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
 
 resource "aws_s3_bucket" "elb" {
-  bucket = "terraform-aws-loadbalancer-c12313"
+  bucket = "terraform-aws-loadbalancer-changeme"
 
   policy = <<EOF
 {
@@ -77,7 +75,7 @@ resource "aws_s3_bucket" "elb" {
       "AWS": "arn:aws:iam::156460612806:root"
     },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::terraform-aws-loadbalancer-c12313/*"
+      "Resource": "arn:aws:s3:::terraform-aws-loadbalancer-changeme/*"
     }
   ]
   }

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -21,7 +21,3 @@ output "origin_id" {
 output "security_group_id" {
   value = "${module.alb.security_group_id}"
 }
-
-output "metric_name" {
-  value = "${coalesce(module.alb.arn, "")}"
-}

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -21,3 +21,7 @@ output "origin_id" {
 output "security_group_id" {
   value = "${module.alb.security_group_id}"
 }
+
+output "metric_name" {
+  value = "${coalesce(module.alb.arn, "")}"
+}

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_dashboard" "main" {
            "width":20,
            "height":6,
            "properties":{
-              "title": "Requestcount & Average Responsetime",
+              "title": "Request count & Average Responsetime",
               "view":"timeSeries",
               "stacked":false,
               "metrics":[

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,8 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "add_cloudwatch_dashboard" {
+  description = "If true, add a cloudwatch dashboard with metrics for the loadbalancer"
+  default     = "false"
+}


### PR DESCRIPTION
The component can now optionally create a Cloud Watch Dashboard with the following metrics

- Average Target Response time 
- Sum Request count
- Current value of ActiveConnections 

